### PR TITLE
enh: UI/UX improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"@mui/icons-material": "^5.10.16",
 		"@mui/material": "^5.10.17",
 		"@reduxjs/toolkit": "^1.9.1",
+		"copy-image-clipboard": "^2.1.2",
 		"file-saver": "^2.0.5",
 		"fuzzysort": "^2.0.4",
 		"html2canvas": "^1.4.1",

--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,5 @@
 #root {
   width: 100vw;
-  max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
   text-align: center;

--- a/src/components/BreakdownListItem/BreakdownListItem.tsx
+++ b/src/components/BreakdownListItem/BreakdownListItem.tsx
@@ -34,8 +34,10 @@ export const BreakdownListItem = ({ item }: BreakdownListItemProps) => {
 
   return (
     <ListItem
+      tabIndex={-1}
       secondaryAction={
         <TextField
+          tabIndex={1}
           fullWidth
           multiline
           value={text}
@@ -53,9 +55,9 @@ export const BreakdownListItem = ({ item }: BreakdownListItemProps) => {
       }
       disablePadding
     >
-      <ListItemButton>
+      <ListItemButton tabIndex={-1}>
         {item.image ? (
-          <ListItemAvatar>
+          <ListItemAvatar tabIndex={-1}>
             <Avatar
               imgProps={{ style: { objectFit: "scale-down" } }}
               variant="square"
@@ -66,7 +68,7 @@ export const BreakdownListItem = ({ item }: BreakdownListItemProps) => {
         ) : (
           <div style={{ height: "40px" }}></div>
         )}
-        <ListItemText primaryTypographyProps={{ maxWidth: "225px", maxHeight: "40px" }} primary={item.name} />
+        <ListItemText tabIndex={-1} primaryTypographyProps={{ maxWidth: "225px", maxHeight: "40px" }} primary={item.name} />
       </ListItemButton>
     </ListItem>
   );

--- a/src/components/ClipboardCopyButtonContainer/ClipboardCopyButtonContainer.tsx
+++ b/src/components/ClipboardCopyButtonContainer/ClipboardCopyButtonContainer.tsx
@@ -1,14 +1,14 @@
-import { Tooltip } from "@mui/material"
+import { Tooltip } from "@mui/material";
+import { canCopyImagesToClipboard } from "copy-image-clipboard";
 
-export const ClipboardCopyButtonContainer = ({ className, children }: { className: string, children: JSX.Element }) => {
+const warningMsg =
+  "Copy Image to Clipboard functionality is only available in Chrome, Edge, Safari, and Opera. " +
+  "If using Firefox, you can set `dom.events.asyncClipboard.clipboardItem` to`true` in about: config.";
+
+export const ClipboardCopyButtonContainer = ({ className, children }: { className: string; children: JSX.Element }) => {
   return (
-    <Tooltip
-      className={className}
-      title="Copy Image to Clipboard functionality is only available in Chrome, Edge, Safari, and Opera. If using Firefox, you can set `dom.events.asyncClipboard.clipboardItem` to `true`."
-    >
-      <span>
-        {children}
-      </span>
+    <Tooltip className={className} title={!canCopyImagesToClipboard() && warningMsg}>
+      <span>{children}</span>
     </Tooltip>
   );
 };

--- a/src/components/ClipboardCopyButtonContainer/ClipboardCopyButtonContainer.tsx
+++ b/src/components/ClipboardCopyButtonContainer/ClipboardCopyButtonContainer.tsx
@@ -1,0 +1,14 @@
+import { Tooltip } from "@mui/material"
+
+export const ClipboardCopyButtonContainer = ({ className, children }: { className: string, children: JSX.Element }) => {
+  return (
+    <Tooltip
+      className={className}
+      title="Copy Image to Clipboard functionality is only available in Chrome, Edge, Safari, and Opera. If using Firefox, you can set `dom.events.asyncClipboard.clipboardItem` to `true`."
+    >
+      <span>
+        {children}
+      </span>
+    </Tooltip>
+  );
+};

--- a/src/components/ItemSelectDialogPopup/ItemSelectDialogPopup.css
+++ b/src/components/ItemSelectDialogPopup/ItemSelectDialogPopup.css
@@ -1,8 +1,14 @@
+.item-select-dialog-paper {
+  /* Prevent unnecessary scrollbar. */
+  overflow-y: hidden;
+}
+
 .dialog-content {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
+  overflow-y: hidden;
 }
 
 .auto-complete {

--- a/src/components/ItemSelectDialogPopup/ItemSelectDialogPopup.tsx
+++ b/src/components/ItemSelectDialogPopup/ItemSelectDialogPopup.tsx
@@ -98,7 +98,9 @@ export const DialogPopup = ({ open, recentlySelectedItems, handleClose, handleSl
   }, [slotIndex]);
 
   return (
-    <Dialog open={open} onClose={handleClose}>
+    <Dialog classes={{
+      paper: 'item-select-dialog-paper'
+    }} open={open} onClose={handleClose}>
       <DialogTitle>Assign an item</DialogTitle>
       <DialogContent
         className="dialog-content"

--- a/src/components/PresetBreakdown/PresetBreakdown.css
+++ b/src/components/PresetBreakdown/PresetBreakdown.css
@@ -1,8 +1,21 @@
 .breakdown-container {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  margin-top: 10px !important;
+}
+
+.breakdown-header {
+  display: flex;
+  justify-content: center;
+  width: 95%;
+  margin: 0 auto;
+}
+
+.breakdown-button {
+  margin: 10px;
 }
 
 .breakdown-inner-container {
@@ -33,8 +46,4 @@
 
 .bold {
   font-weight: bold;
-}
-
-.breakdown-button {
-  margin: 10px auto !important;
 }

--- a/src/components/PresetBreakdown/PresetBreakdown.css
+++ b/src/components/PresetBreakdown/PresetBreakdown.css
@@ -5,13 +5,16 @@
   justify-content: center;
 }
 
-.other-container {
+.breakdown-inner-container {
   display: flex;
+  justify-content: center;
   flex-direction: row;
+  flex-wrap: wrap;
+  max-width: 100%;
   background-color: #181818;
 }
 
-.other-container div:hover {
+.breakdown-inner-container div:hover {
   background-color: #181818;
 }
 

--- a/src/components/PresetBreakdown/PresetBreakdown.tsx
+++ b/src/components/PresetBreakdown/PresetBreakdown.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { Button } from "@mui/material";
+import { Button, CardActions } from "@mui/material";
 import List from "@mui/material/List";
 
 import { useAppSelector } from "../../redux/hooks";
@@ -8,7 +8,7 @@ import { selectPreset } from "../../redux/store/reducers/preset-reducer";
 import { ItemData } from "../../types/inventory-slot";
 import { BreakdownHeader } from "../BreakdownHeader/BreakdownHeader";
 import { BreakdownListItem } from "../BreakdownListItem/BreakdownListItem";
-import { exportAsImage } from "../../utility/export-to-png";
+import { copyImageToClipboard, exportAsImage } from "../../utility/export-to-png";
 
 import "./PresetBreakdown.css";
 
@@ -62,8 +62,20 @@ export const PresetBreakdown = () => {
     await exportAsImage(exportRef.current, `BREAK_DOWN_${name.replaceAll(" ", "_")}`);
   }, [name, exportRef]);
 
+  const copyBreakdownToClipboard = useCallback(async () => {
+    await copyImageToClipboard(exportRef.current);
+  }, [exportRef]);
+
   return (
     <div className="breakdown-container">
+      <div className="breakdown-header">
+          <Button className="breakdown-button" variant="contained" color="success" onClick={exportBreakdown}>
+            Save Breakdown as PNG
+          </Button>
+          <Button className="breakdown-button" variant="outlined" color="secondary" onClick={copyBreakdownToClipboard}>
+            Copy Breakdown to Clipboard
+          </Button>
+      </div>
       <div className="breakdown-inner-container" ref={exportRef}>
         <div className="equipment-breakdown-container">
           <List className="breakdown-list" dense>
@@ -85,9 +97,6 @@ export const PresetBreakdown = () => {
             )
         )}
       </div>
-      <Button className="breakdown-button" variant="contained" color="success" onClick={exportBreakdown}>
-        Export Breakdown
-      </Button>
     </div>
   );
 };

--- a/src/components/PresetBreakdown/PresetBreakdown.tsx
+++ b/src/components/PresetBreakdown/PresetBreakdown.tsx
@@ -64,7 +64,7 @@ export const PresetBreakdown = () => {
 
   return (
     <div className="breakdown-container">
-      <div className="other-container" ref={exportRef}>
+      <div className="breakdown-inner-container" ref={exportRef}>
         <div className="equipment-breakdown-container">
           <List className="breakdown-list" dense>
             <BreakdownHeader />

--- a/src/components/PresetBreakdown/PresetBreakdown.tsx
+++ b/src/components/PresetBreakdown/PresetBreakdown.tsx
@@ -11,6 +11,8 @@ import { BreakdownListItem } from "../BreakdownListItem/BreakdownListItem";
 import { copyImageToClipboard, exportAsImage } from "../../utility/export-to-png";
 
 import "./PresetBreakdown.css";
+import { canCopyImagesToClipboard } from "copy-image-clipboard";
+import { ClipboardCopyButtonContainer } from "../ClipboardCopyButtonContainer/ClipboardCopyButtonContainer";
 
 // This is used to map the equipmentSlots array (0-12) to a column
 // Used in getMappedEquipment
@@ -69,12 +71,24 @@ export const PresetBreakdown = () => {
   return (
     <div className="breakdown-container">
       <div className="breakdown-header">
-          <Button className="breakdown-button" variant="contained" color="success" onClick={exportBreakdown}>
-            Save Breakdown as PNG
-          </Button>
-          <Button className="breakdown-button" variant="outlined" color="secondary" onClick={copyBreakdownToClipboard}>
+        <Button
+          className="breakdown-button"
+          variant="contained"
+          color="success"
+          onClick={exportBreakdown}
+        >
+          Save Breakdown as PNG
+        </Button> 
+        <ClipboardCopyButtonContainer className="breakdown-button">
+          <Button
+            variant="outlined"
+            color="secondary"
+            disabled={!canCopyImagesToClipboard()}
+            onClick={copyBreakdownToClipboard}
+          >
             Copy Breakdown to Clipboard
           </Button>
+        </ClipboardCopyButtonContainer>
       </div>
       <div className="breakdown-inner-container" ref={exportRef}>
         <div className="equipment-breakdown-container">

--- a/src/components/PresetBreakdown/PresetBreakdown.tsx
+++ b/src/components/PresetBreakdown/PresetBreakdown.tsx
@@ -13,6 +13,7 @@ import { copyImageToClipboard, exportAsImage } from "../../utility/export-to-png
 import "./PresetBreakdown.css";
 import { canCopyImagesToClipboard } from "copy-image-clipboard";
 import { ClipboardCopyButtonContainer } from "../ClipboardCopyButtonContainer/ClipboardCopyButtonContainer";
+import { useSnackbar } from "notistack";
 
 // This is used to map the equipmentSlots array (0-12) to a column
 // Used in getMappedEquipment
@@ -22,6 +23,7 @@ const maxLength = 14;
 
 export const PresetBreakdown = () => {
   const exportRef = useRef<HTMLDivElement>(null);
+  const { enqueueSnackbar } = useSnackbar();
   const [mappedEquipment, setMappedEquipment] = useState<ItemData[]>();
   const [uniqueInventoryItems, setUniqueInventoryItems] = useState<ItemData[][]>();
 
@@ -65,7 +67,9 @@ export const PresetBreakdown = () => {
   }, [name, exportRef]);
 
   const copyBreakdownToClipboard = useCallback(async () => {
-    await copyImageToClipboard(exportRef.current);
+    await copyImageToClipboard(exportRef.current, () => {
+      enqueueSnackbar("Failed to copy image to clipboard", { variant: 'error'});
+    });
   }, [exportRef]);
 
   return (

--- a/src/components/PresetEditor/PresetEditor.css
+++ b/src/components/PresetEditor/PresetEditor.css
@@ -39,6 +39,10 @@
   padding: 0 !important;
 }
 
+.preset-buttons__button {
+  margin: 0 10px;
+}
+
 .preset-buttons button {
   height: 25px;
 }

--- a/src/components/PresetEditor/PresetEditor.tsx
+++ b/src/components/PresetEditor/PresetEditor.tsx
@@ -1,9 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 
+import { Tooltip } from "@mui/material";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
 import CardContent from "@mui/material/CardContent";
+import { canCopyImagesToClipboard } from 'copy-image-clipboard'
 
 import {
   resetSlots,
@@ -22,6 +24,7 @@ import { DialogPopup } from "../ItemSelectDialogPopup/ItemSelectDialogPopup";
 import { Equipment, Inventory } from "../SlotSection/SlotSection";
 
 import "./PresetEditor.css";
+import { ClipboardCopyButtonContainer } from "../ClipboardCopyButtonContainer/ClipboardCopyButtonContainer";
 
 export const PresetEditor = () => {
   const dispatch = useAppDispatch();
@@ -76,7 +79,7 @@ export const PresetEditor = () => {
 
   const onCopyToClipboard = useCallback(async () => {
     await copyImageToClipboard(exportRef.current);
-  }, [name]);
+  }, []);
 
   return (
     <>
@@ -104,9 +107,17 @@ export const PresetEditor = () => {
           <Button color="success" variant="contained" size="small" onClick={onSave}>
             Save as PNG
           </Button>
-          <Button color="secondary" variant="outlined" size="small" onClick={onCopyToClipboard}>
-            Copy Image to Clipboard
-          </Button>
+          <ClipboardCopyButtonContainer className="preset-buttons__button">
+            <Button
+              color="secondary"
+              variant="outlined"
+              size="small"
+              disabled={!canCopyImagesToClipboard()}
+              onClick={onCopyToClipboard}
+            >
+              Copy Image to Clipboard
+            </Button>
+          </ClipboardCopyButtonContainer>
         </CardActions>
       </Card>
       <DialogPopup

--- a/src/components/PresetEditor/PresetEditor.tsx
+++ b/src/components/PresetEditor/PresetEditor.tsx
@@ -25,9 +25,11 @@ import { Equipment, Inventory } from "../SlotSection/SlotSection";
 
 import "./PresetEditor.css";
 import { ClipboardCopyButtonContainer } from "../ClipboardCopyButtonContainer/ClipboardCopyButtonContainer";
+import { useSnackbar } from "notistack";
 
 export const PresetEditor = () => {
   const dispatch = useAppDispatch();
+  const { enqueueSnackbar } = useSnackbar();
 
   const { presetName: name, inventorySlots, equipmentSlots, slotType, slotIndex } = useAppSelector(selectPreset);
   const recentItems = useAppSelector(selectRecentItems);
@@ -78,7 +80,9 @@ export const PresetEditor = () => {
   }, [name]);
 
   const onCopyToClipboard = useCallback(async () => {
-    await copyImageToClipboard(exportRef.current);
+    await copyImageToClipboard(exportRef.current, () => {
+      enqueueSnackbar("Failed to copy image to clipboard", { variant: 'error'});
+    });
   }, []);
 
   return (

--- a/src/components/PresetEditor/PresetEditor.tsx
+++ b/src/components/PresetEditor/PresetEditor.tsx
@@ -17,7 +17,7 @@ import { addToQueue, selectRecentItems } from "../../redux/store/reducers/recent
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { ItemData } from "../../types/inventory-slot";
 import { SlotType } from "../../types/slot-type";
-import { exportAsImage } from "../../utility/export-to-png";
+import { copyImageToClipboard, exportAsImage } from "../../utility/export-to-png";
 import { DialogPopup } from "../ItemSelectDialogPopup/ItemSelectDialogPopup";
 import { Equipment, Inventory } from "../SlotSection/SlotSection";
 
@@ -74,6 +74,10 @@ export const PresetEditor = () => {
     await exportAsImage(exportRef.current, `PRESET_${name.replaceAll(" ", "_")}`);
   }, [name]);
 
+  const onCopyToClipboard = useCallback(async () => {
+    await copyImageToClipboard(exportRef.current);
+  }, [name]);
+
   return (
     <>
       <Card className="container">
@@ -99,6 +103,9 @@ export const PresetEditor = () => {
           </Button>
           <Button color="success" variant="contained" size="small" onClick={onSave}>
             Save as PNG
+          </Button>
+          <Button color="secondary" variant="outlined" size="small" onClick={onCopyToClipboard}>
+            Copy Image to Clipboard
           </Button>
         </CardActions>
       </Card>

--- a/src/utility/export-to-png.ts
+++ b/src/utility/export-to-png.ts
@@ -7,6 +7,31 @@ export const exportAsImage = async (element: HTMLElement | null, preface: string
     return;
   }
 
+  await createCanvas(element, (blob: string) => {
+    downloadImage(blob, preface);
+  });
+};
+
+export const copyImageToClipboard = async (element: HTMLElement | null): Promise<void> => {
+  if (!element) {
+    return;
+  }
+
+  await createCanvas(element, (_imageBlobURL: string, canvas: HTMLCanvasElement) => {
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          // TODO: Failure snackbar?
+          return;
+        }
+        
+        console.error(blob);
+        const item = new ClipboardItem({ 'image/png': blob });
+        navigator.clipboard.write([item]); 
+      })
+  });
+};
+
+const createCanvas = ( async (element: HTMLElement, callback: (imageBlobURL: string, canvas: HTMLCanvasElement) => void): Promise<void> => {
   const previousheight = element.style.height;
 
   const html = document.getElementsByTagName("html")[0];
@@ -32,12 +57,11 @@ export const exportAsImage = async (element: HTMLElement | null, preface: string
     logging: false,
     useCORS: true,
   });
-  const image = canvas.toDataURL("image/png", 1.0);
-  downloadImage(image, preface);
-
+  const imageBlobURL = canvas.toDataURL("image/png", 1.0);
+  callback(imageBlobURL, canvas);
   // reset height
   element.style.height = previousheight;
-};
+})
 
 const downloadImage = (blob: string, preface: string): void => {
   const fakeLink = window.document.createElement("a");
@@ -52,3 +76,4 @@ const downloadImage = (blob: string, preface: string): void => {
 
   fakeLink.remove();
 };
+

--- a/src/utility/export-to-png.ts
+++ b/src/utility/export-to-png.ts
@@ -12,7 +12,7 @@ export const exportAsImage = async (element: HTMLElement | null, preface: string
   });
 };
 
-export const copyImageToClipboard = async (element: HTMLElement | null): Promise<void> => {
+export const copyImageToClipboard = async (element: HTMLElement | null, onError: () => void): Promise<void> => {
   if (!element) {
     return;
   }
@@ -20,11 +20,10 @@ export const copyImageToClipboard = async (element: HTMLElement | null): Promise
   await createCanvas(element, (_imageBlobURL: string, canvas: HTMLCanvasElement) => {
       canvas.toBlob((blob) => {
         if (!blob) {
-          // TODO: Failure snackbar?
+          onError();
           return;
         }
         
-        console.error(blob);
         const item = new ClipboardItem({ 'image/png': blob });
         navigator.clipboard.write([item]); 
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -787,6 +787,11 @@ convert-source-map@^1.5.0, convert-source-map@^1.7.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
 
+copy-image-clipboard@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/copy-image-clipboard/-/copy-image-clipboard-2.1.2.tgz#7965038faa036b1aed451df207f14b52838286a1"
+  integrity sha512-3VCXVl2IpFfOyD8drv9DozcNlwmqBqxOlsgkEGyVAzadjlPk1go8YNZyy8QmTnwHPxSFpeCR9OdsStEdVK7qDA==
+
 cosmiconfig@^7.0.0:
   version "7.1.0"
   resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz"


### PR DESCRIPTION
This PR makes a bunch of small changes, e.g.
* Wrap preset breakdown columns so that they aren't hidden when 3 columns exist in a smaller window.
* Fix tabindex for breakdown list so you can tab between the inputs.
* Add Copy Image to Clipboard buttons for both preset and breakdown, so you can paste directly into Imgur.
* Prevent unnecessary scrollbar in the item dialog when the dropdown is opened.