### PR TITLE
enh: add preset name to actions area

### DIFF
--- a/src/components/FamiliarSection/FamiliarSection.css
+++ b/src/components/FamiliarSection/FamiliarSection.css
@@ -34,6 +34,6 @@
   border-color: rgba(255, 255, 255, 0.45);
 }
 
-.familiar-section__list-item:hover > .relic-section__add-relic {
+.familiar-section__list-item:hover > .familiar-section__add-familiar {
   color: white;
 }

--- a/src/components/PresetActions/PresetActions.tsx
+++ b/src/components/PresetActions/PresetActions.tsx
@@ -2,7 +2,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import LinkIcon from '@mui/icons-material/Link';
 import SaveIcon from '@mui/icons-material/Save';
 import SaveAsIcon from '@mui/icons-material/SaveAs';
-import { Button, ButtonGroup, Link } from '@mui/material';
+import { Button, ButtonGroup, Link, TextField } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import React, { useCallback, useState } from 'react';
 import { uploadPreset } from '../../api/upload-preset';
@@ -116,6 +116,16 @@ export const PresetActions = ({
 
   return (
     <div className="preset-actions">
+      {/* Details */}
+      <fieldset className="preset-actions__fieldset preset-actions__details">
+        <legend>Details</legend>
+        <TextField
+          label="Name"
+          value={presetName}
+          disabled
+          fullWidth
+        />
+      </fieldset>
       {/* Save actions */}
       <fieldset className="preset-actions__fieldset preset-actions__save">
         <legend>Save</legend>


### PR DESCRIPTION
This adds a read-only field to the actions area that displays the preset name, rather than rendering it inside the selection dropdown. This is better for presets loaded from a link.

I plan to move the "load preset" functionality elsewhere and remove the ability to edit the name of existing preset (this is replaced by Save As functionality).

<img width="321" alt="image" src="https://user-images.githubusercontent.com/3266047/234977600-57c85313-c79f-440f-b04b-064c3e9f7623.png">

Other changes:
* fix: hover styling for Add Familiar button.