### PR TITLE
enh: add HTML support to breakdown notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "file-saver": "^2.0.5",
     "fuzzysort": "^2.0.4",
     "html2canvas": "^1.4.1",
+    "linkify-html": "^4.1.1",
+    "linkifyjs": "^4.1.1",
     "notistack": "^2.0.8",
     "react": "^18.2.0",
     "react-contenteditable": "^3.3.7",

--- a/src/components/BreakdownListItem/BreakdownListItem.tsx
+++ b/src/components/BreakdownListItem/BreakdownListItem.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useRef } from 'react';
 import ContentEditable, { type ContentEditableEvent } from 'react-contenteditable';
 import { useDispatch } from 'react-redux';
 import sanitizeHtml from 'sanitize-html';
+import linkifyHtml from 'linkify-html';
 
 import Avatar from '@mui/material/Avatar';
 import ListItem from '@mui/material/ListItem';
@@ -57,6 +58,13 @@ export const BreakdownListItem = ({ item, type }: BreakdownListItemProps): JSX.E
     [item]
   );
 
+  const breakdownNotesWithLinks = linkifyHtml(breakdownNotes.current, {
+    attributes: {
+      contenteditable: false
+    },
+    defaultProtocol: 'https'
+  });
+
   return (
     <ListItem
       tabIndex={-1}
@@ -68,7 +76,7 @@ export const BreakdownListItem = ({ item, type }: BreakdownListItemProps): JSX.E
         <ContentEditable
           placeholder={item.breakdownNotes}
           className="inner-notes-field"
-          html={breakdownNotes.current}
+          html={breakdownNotesWithLinks}
           onChange={onChange}
           onBlur={onBlur}
         />

--- a/src/components/PresetActions/PresetActions.tsx
+++ b/src/components/PresetActions/PresetActions.tsx
@@ -17,6 +17,14 @@ import { SavePresetDialog, SavePresetDialogState } from '../SavePresetDialog/Sav
 import './PresetActions.css';
 import { ClipboardCopyButtonContainer } from '../ClipboardCopyButtonContainer/ClipboardCopyButtonContainer';
 
+const getLinkForPreset = (id: string): string => {
+  if (document.location.hostname === 'localhost') {
+    return `${document.location.origin}/#/${id}`;
+  }
+
+  return `https://pvme.github.io/preset-maker/#/${id}`;
+};
+
 export const PresetActions = ({
   presetExportRef
 }: {
@@ -100,7 +108,7 @@ export const PresetActions = ({
       const generatingLinkSnackbarKey = enqueueSnackbar('Generating shareable link...', { variant: 'info' });
       const id = await uploadPreset(stringifiedPresetData);
 
-      const link = `https://pvme.github.io/preset-maker/#/${id}`;
+      const link = getLinkForPreset(id);
       setGeneratedLink(link);
 
       await navigator.clipboard.writeText(link);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,6 +2692,16 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-html@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/linkify-html/-/linkify-html-4.1.1.tgz#da88082149471bb6d3945fabf0d855a33c7f4120"
+  integrity sha512-7RcF7gIhEOGBBvs7orCJ2tevaz7iF0ZLZSRPWNNBOnW/uGjOOQYB+ztSeHF6dchMC2dM9H8zZlt6Z959bjteaw==
+
+linkifyjs@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-4.1.1.tgz#73d427e3bbaaf4ca8e71c589ad4ffda11a9a5fde"
+  integrity sha512-zFN/CTVmbcVef+WaDXT63dNzzkfRBKT1j464NJQkV7iSgJU0sLBus9W0HBwnXK13/hf168pbrx/V/bjEHOXNHA==
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz"


### PR DESCRIPTION
This is done via a new dependency that converts all links within the notes to <a> tags. The `contenteditable = false` attribute is required in order for the links to be clickable.

This also makes the testing process for shareable links slightly easier by checking the document hostname, so that links copied to clipboard locally use `localhost`.