### PR TITLE
enh: add preset notes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -101,8 +101,13 @@
   margin-right: 8px;
 }
 
+<<<<<<< HEAD
 .mt-auto {
   margin-top: auto;
+=======
+.ml-8 {
+  margin-right: 8px;
+>>>>>>> 54c00ac (enh: add preset-level notes')
 }
 
 .cursor-pointer:hover {

--- a/src/App.css
+++ b/src/App.css
@@ -101,13 +101,12 @@
   margin-right: 8px;
 }
 
-<<<<<<< HEAD
 .mt-auto {
   margin-top: auto;
-=======
+}
+
 .ml-8 {
   margin-right: 8px;
->>>>>>> 54c00ac (enh: add preset-level notes')
 }
 
 .cursor-pointer:hover {

--- a/src/api/get-preset.ts
+++ b/src/api/get-preset.ts
@@ -24,8 +24,8 @@ const unpackData = async (stored: {
   familiars: Familiars
 }): Promise<SavedPresetData> => {
   const newPreset: SavedPresetData = {
-    presetName: '',
-    presetNotes: '',
+    presetName: stored.presetName,
+    presetNotes: stored.presetNotes,
     inventorySlots: [],
     equipmentSlots: [],
     relics: { primaryRelics: [], alternativeRelics: [] },

--- a/src/api/get-preset.ts
+++ b/src/api/get-preset.ts
@@ -18,12 +18,14 @@ export const getPreset = async (id: string): Promise<SavedPresetData> => {
 const unpackData = async (stored: {
   equipmentSlots: any
   presetName: any
+  presetNotes: string
   inventorySlots: string | any[]
   relics: Relics
   familiars: Familiars
 }): Promise<SavedPresetData> => {
   const newPreset: SavedPresetData = {
     presetName: '',
+    presetNotes: '',
     inventorySlots: [],
     equipmentSlots: [],
     relics: { primaryRelics: [], alternativeRelics: [] },

--- a/src/components/BreakdownListItem/BreakdownListItem.tsx
+++ b/src/components/BreakdownListItem/BreakdownListItem.tsx
@@ -1,9 +1,6 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 
-import ContentEditable, { type ContentEditableEvent } from 'react-contenteditable';
 import { useDispatch } from 'react-redux';
-import sanitizeHtml from 'sanitize-html';
-import linkifyHtml from 'linkify-html';
 
 import Avatar from '@mui/material/Avatar';
 import ListItem from '@mui/material/ListItem';
@@ -11,42 +8,20 @@ import ListItemAvatar from '@mui/material/ListItemAvatar';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 
-import { type ItemData } from '../../types/item-data';
 import { setBreakdown } from '../../redux/store/reducers/preset-reducer';
 import { type BreakdownType } from '../../types/breakdown';
+import { type ItemData } from '../../types/item-data';
 
+import { NotesField } from '../NotesField/NotesField';
 import './BreakdownListItem.css';
-import { emojify } from '../../utility/emojify';
 
 export interface BreakdownListItemProps {
   item: ItemData
   type: BreakdownType
 }
 
-const allowedHtmlTags = sanitizeHtml.defaults.allowedTags.concat(['img']);
-const allowedHtmlAttributes = {
-  ...sanitizeHtml.defaults.allowedAttributes,
-  img: ['class', 'src']
-};
-const transformNotes = (input: string): string => {
-  const sanitizedHtml = sanitizeHtml(input, {
-    allowedTags: allowedHtmlTags,
-    allowedAttributes: allowedHtmlAttributes
-  });
-  return emojify(sanitizedHtml);
-};
-
 export const BreakdownListItem = ({ item, type }: BreakdownListItemProps): JSX.Element => {
   const dispatch = useDispatch();
-  const [formattedNotes, setFormattedNotes] = useState<string>(item.breakdownNotes ?? '');
-
-  const onChange = useCallback((event: ContentEditableEvent) => {
-    if (event.currentTarget.innerHTML === null || event.currentTarget.innerHTML === undefined) {
-      return;
-    }
-
-    setFormattedNotes(transformNotes(event.currentTarget.innerHTML));
-  }, []);
 
   const handleRecentClick = useCallback(
     (item: ItemData) => {
@@ -55,31 +30,18 @@ export const BreakdownListItem = ({ item, type }: BreakdownListItemProps): JSX.E
     []
   );
 
-  const onBlur = useCallback(
-    (event: React.FocusEvent<HTMLDivElement>) => {
-      if (event.currentTarget.innerHTML === null || event.currentTarget.innerHTML === undefined) {
-        return;
-      }
-
+  const onNotesBlur = useCallback(
+    (formattedNotes: string) => {
       dispatch(
         setBreakdown({
           breakdownType: type,
           itemName: item.label,
-          description: transformNotes(event.currentTarget.innerHTML)
+          description: formattedNotes
         })
       );
     },
     [type, item.label]
   );
-
-  const breakdownNotesWithLinks = linkifyHtml(formattedNotes, {
-    attributes: {
-      contenteditable: false
-    },
-    defaultProtocol: 'https'
-  });
-
-  const breakdownNotesWithEmojisAndLinks = emojify(breakdownNotesWithLinks);
 
   return (
     <ListItem
@@ -90,12 +52,11 @@ export const BreakdownListItem = ({ item, type }: BreakdownListItemProps): JSX.E
         secondaryAction: 'notes-field-outer-two'
       }}
       secondaryAction={
-        <ContentEditable
+        <NotesField
           placeholder={item.breakdownNotes}
           className="inner-notes-field"
-          html={breakdownNotesWithEmojisAndLinks}
-          onChange={onChange}
-          onBlur={onBlur}
+          initialValue={item.breakdownNotes}
+          onBlur={onNotesBlur}
         />
       }
       disablePadding

--- a/src/components/HeaderBar/HeaderBar.tsx
+++ b/src/components/HeaderBar/HeaderBar.tsx
@@ -30,7 +30,7 @@ export const HeaderBar = (): JSX.Element => {
   const navigate = useNavigate();
 
   const dispatch = useAppDispatch();
-  const { presetName, inventorySlots, equipmentSlots, relics, familiars } =
+  const { presetName, presetNotes, inventorySlots, equipmentSlots, relics, familiars } =
     useAppSelector(selectPreset);
   const [helpDialogOpen, setHelpDialogOpen] = useState<boolean>(false);
   const { enqueueSnackbar } = useSnackbar();
@@ -38,6 +38,7 @@ export const HeaderBar = (): JSX.Element => {
   const exportData = useCallback(() => {
     const stringifiedPresetData = sanitizeAndStringifyPreset({
       presetName,
+      presetNotes,
       equipmentSlots,
       inventorySlots,
       relics,
@@ -47,7 +48,7 @@ export const HeaderBar = (): JSX.Element => {
       `PRESET_${presetName.replaceAll(' ', '_')}`,
       stringifiedPresetData
     );
-  }, [presetName, inventorySlots, equipmentSlots]);
+  }, [presetName, presetNotes, inventorySlots, equipmentSlots, relics, familiars]);
 
   const importData = useCallback(() => {
     inputFile.current?.click();

--- a/src/components/NotesField/NotesField.css
+++ b/src/components/NotesField/NotesField.css
@@ -1,0 +1,30 @@
+.notes-field {
+  padding: 8px;
+  padding-left: 12px;
+  color: rgba(255, 255, 255);
+  border-radius: 4px;
+  overflow-wrap: break-word;
+  border: 1px solid rgba(255, 255, 255, 0.23);
+  min-height: 36px;
+  line-height: 28px;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+.notes-field:hover {
+  border-color: white;
+}
+
+.notes-field:active,
+.notes-field:focus {
+  border-color: #90caf9;
+  outline: 0px;
+  cursor: text;
+}
+
+[contenteditable=true]:empty:before {
+  content: attr(placeholder);
+  display: block;
+  color: rgba(255, 255, 255, 0.55);
+}

--- a/src/components/NotesField/NotesField.tsx
+++ b/src/components/NotesField/NotesField.tsx
@@ -1,0 +1,86 @@
+import linkifyHtml from 'linkify-html';
+import { init } from 'linkifyjs';
+import React, { useCallback, useEffect, useState } from 'react';
+import ContentEditable, { type ContentEditableEvent } from 'react-contenteditable';
+import sanitizeHtml from 'sanitize-html';
+import { emojify } from '../../utility/emojify';
+import './NotesField.css';
+
+export interface NotesFieldProps {
+  className?: string
+  placeholder?: string
+  initialValue?: string
+  onBlur: (transformedNotes: string) => void
+}
+
+const allowedHtmlTags = sanitizeHtml.defaults.allowedTags.concat(['img', 'a']);
+const allowedHtmlAttributes = {
+  ...sanitizeHtml.defaults.allowedAttributes,
+  img: ['class', 'src'],
+  a: ['href', 'contenteditable']
+};
+
+const sanitizeAndEmojifyInput = (input?: string): string => {
+  if (input === undefined) {
+    return '';
+  }
+
+  const sanitizedHtml = sanitizeHtml(input, {
+    allowedTags: allowedHtmlTags,
+    allowedAttributes: allowedHtmlAttributes
+  });
+  return emojify(sanitizedHtml);
+};
+
+const linkifyInput = (input: string): string => {
+  return linkifyHtml(input, {
+    attributes: {
+      contenteditable: false
+    },
+    defaultProtocol: 'https'
+  });
+};
+
+const formatInput = (input?: string): string => {
+  return linkifyInput(sanitizeAndEmojifyInput(input));
+};
+
+export const NotesField = ({ className, placeholder, initialValue, onBlur }: NotesFieldProps): JSX.Element => {
+  const [formattedNotes, setFormattedNotes] = useState<string>(formatInput(initialValue) ?? '');
+
+  const onNotesFieldChange = useCallback(
+    (event: ContentEditableEvent) => {
+      if (event.currentTarget.innerHTML === null || event.currentTarget.innerHTML === undefined) {
+        return;
+      }
+
+      setFormattedNotes(sanitizeAndEmojifyInput(event.currentTarget.innerHTML));
+    },
+    []
+  );
+
+  useEffect(() => {
+    setFormattedNotes(formatInput(initialValue));
+  }, [initialValue]);
+
+  const onNotesFieldBlur = useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      if (event.currentTarget.innerHTML === null || event.currentTarget.innerHTML === undefined) {
+        return;
+      }
+
+      onBlur(formatInput(event.currentTarget.innerHTML));
+    },
+    []
+  );
+
+  return (
+    <ContentEditable
+      className={`notes-field ${className ?? ''}`}
+      placeholder={placeholder}
+      html={formattedNotes}
+      onChange={onNotesFieldChange}
+      onBlur={onNotesFieldBlur}
+    />
+  );
+};

--- a/src/components/PresetActions/PresetActions.css
+++ b/src/components/PresetActions/PresetActions.css
@@ -1,9 +1,12 @@
+<<<<<<< HEAD
 .preset-actions {
   display: flex;
   flex-direction: column;
   margin-left: 16px;
 }
 
+=======
+>>>>>>> 54c00ac (enh: add preset-level notes')
 .preset-actions__fieldset {
   text-align: left;
   padding-right: 8px;

--- a/src/components/PresetActions/PresetActions.css
+++ b/src/components/PresetActions/PresetActions.css
@@ -1,12 +1,3 @@
-<<<<<<< HEAD
-.preset-actions {
-  display: flex;
-  flex-direction: column;
-  margin-left: 16px;
-}
-
-=======
->>>>>>> 54c00ac (enh: add preset-level notes')
 .preset-actions__fieldset {
   text-align: left;
   padding-right: 8px;

--- a/src/components/PresetActions/PresetActions.css
+++ b/src/components/PresetActions/PresetActions.css
@@ -41,6 +41,10 @@
   margin-top: 16px;
 }
 
+.preset-and-actions {
+  display: flex;
+}
+
 
 /* Responsive + mobile styling */
 

--- a/src/components/PresetActions/PresetActions.tsx
+++ b/src/components/PresetActions/PresetActions.tsx
@@ -16,6 +16,7 @@ import { ResetConfirmationDialog } from '../ResetConfirmationDialog/ResetConfirm
 import { SavePresetDialog, SavePresetDialogState } from '../SavePresetDialog/SavePresetDialog';
 import './PresetActions.css';
 import { ClipboardCopyButtonContainer } from '../ClipboardCopyButtonContainer/ClipboardCopyButtonContainer';
+import { PresetDetails } from '../PresetDetails/PresetDetails';
 
 const getLinkForPreset = (id: string): string => {
   if (document.location.hostname === 'localhost') {
@@ -129,16 +130,6 @@ export const PresetActions = ({
 
   return (
     <div className="preset-actions">
-      {/* Details */}
-      <fieldset className="preset-actions__fieldset preset-actions__details">
-        <legend>Details</legend>
-        <TextField
-          label="Name"
-          value={presetName}
-          disabled
-          fullWidth
-        />
-      </fieldset>
       <div className="desktop-only">
         {/* Save actions */}
         <fieldset className="preset-actions__fieldset preset-actions__save">

--- a/src/components/PresetActions/PresetActions.tsx
+++ b/src/components/PresetActions/PresetActions.tsx
@@ -38,6 +38,7 @@ export const PresetActions = ({
     familiars,
     inventorySlots,
     presetName,
+    presetNotes,
     relics
   } = useAppSelector(selectPreset);
 
@@ -62,6 +63,7 @@ export const PresetActions = ({
   const onSaveClick = useCallback(() => {
     LocalStorage.savePresetWithoutConfirmation({
       presetName,
+      presetNotes,
       inventorySlots,
       equipmentSlots,
       relics,
@@ -98,6 +100,7 @@ export const PresetActions = ({
       const presetImage = await getImageFromElement(presetExportRef);
       const stringifiedPresetData = sanitizeAndStringifyPreset({
         presetName,
+        presetNotes,
         equipmentSlots,
         inventorySlots,
         relics,

--- a/src/components/PresetActions/PresetActions.tsx
+++ b/src/components/PresetActions/PresetActions.tsx
@@ -2,7 +2,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import LinkIcon from '@mui/icons-material/Link';
 import SaveIcon from '@mui/icons-material/Save';
 import SaveAsIcon from '@mui/icons-material/SaveAs';
-import { Button, ButtonGroup, Link, TextField } from '@mui/material';
+import { Button, ButtonGroup, Link } from '@mui/material';
 import { canCopyImagesToClipboard } from 'copy-image-clipboard';
 import { useSnackbar } from 'notistack';
 import React, { useCallback, useState } from 'react';

--- a/src/components/PresetDetails/PresetDetails.css
+++ b/src/components/PresetDetails/PresetDetails.css
@@ -1,0 +1,18 @@
+.preset-details {
+  text-align: left;
+  padding-right: 8px;
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.preset-details__notes {
+  margin-top: 8px;
+  background: none;
+  width: 100%;
+  max-width: 278px;
+  font: inherit;
+  padding: 16.5px 14px;
+  border-radius: 4px;
+  border-color: rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.5);
+}

--- a/src/components/PresetDetails/PresetDetails.css
+++ b/src/components/PresetDetails/PresetDetails.css
@@ -5,14 +5,29 @@
   border-color: rgba(255, 255, 255, 0.25);
 }
 
+.preset-details__label {
+  margin: 6px;
+}
+
+.preset-details__label:first-of-type {
+  margin-top: 0;
+}
+
 .preset-details__notes {
   margin-top: 8px;
   background: none;
   width: 100%;
   max-width: 278px;
-  font: inherit;
-  padding: 16.5px 14px;
+  padding: 8px;
   border-radius: 4px;
   border-color: rgba(255, 255, 255, 0.25);
-  color: rgba(255, 255, 255, 0.5);
+}
+
+.preset-details__name > div > input {
+  font-size: 14px;
+  padding: 12px;
+}
+
+.preset-details__name > .Mui-focused > fieldset {
+  border-width: 1px !important;
 }

--- a/src/components/PresetDetails/PresetDetails.tsx
+++ b/src/components/PresetDetails/PresetDetails.tsx
@@ -1,49 +1,68 @@
-import React, { useCallback } from 'react';
-import { TextField } from '@mui/material';
-import TextareaAutosize from '@mui/base/TextareaAutosize';
-import './PresetDetails.css';
+import { InputLabel, TextField } from '@mui/material';
+import React, { useCallback, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import './PresetDetails.css';
 
-import { selectPreset, setNotes } from '../../redux/store/reducers/preset-reducer';
+import { selectPreset, setPresetNotes, setPresetName } from '../../redux/store/reducers/preset-reducer';
+import { NotesField } from '../NotesField/NotesField';
 
 export const PresetDetails = (): JSX.Element => {
   const dispatch = useAppDispatch();
   const {
     presetName,
-    notes
+    presetNotes
   } = useAppSelector(selectPreset);
 
-  const onNotesChange = useCallback(
-    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-      // TODO: Emojify it
-      dispatch(setNotes(event.currentTarget.value));
+  const [name, setName] = useState<string>(presetName);
+
+  const onNotesBlur = useCallback(
+    (formattedNotes: string) => {
+      dispatch(setPresetNotes(formattedNotes));
     },
-    [notes]
+    [presetNotes]
   );
 
+  const onNameChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setName(event.currentTarget.value);
+    },
+    [name]
+  );
+
+  const onNameBlur = useCallback(
+    () => {
+      dispatch(setPresetName(name));
+    },
+    [name]
+  );
+
+  const placeholder = presetName.length > 0 ? presetName : 'Add a name...';
+  const value = name.length > 0 ? name : presetName;
   return (
     <>
       <fieldset className="preset-details">
         <legend>Details</legend>
+        <InputLabel className="preset-details__label">
+          Name
+        </InputLabel>
         <TextField
-          label="Name"
-          value={presetName}
-          disabled
+          className="preset-details__name"
+          placeholder={placeholder}
+          value={value}
           fullWidth
+          onChange={onNameChange}
+          onBlur={onNameBlur}
         />
-        <div>
-          <TextareaAutosize
-            placeholder="Notes"
-            className="preset-details__notes"
-            minRows={2}
-            maxRows={4}
-            value={notes}
-            onChange={onNotesChange}
-            spellCheck={false}
-          />
-        </div>
+        <InputLabel className="preset-details__label">
+          Notes
+        </InputLabel>
+        <NotesField
+          placeholder="Add notes..."
+          className="preset-details__notes"
+          initialValue={presetNotes}
+          onBlur={onNotesBlur}
+        />
       </fieldset>
-    {/* TODO Add notes */}
     </>
   );
 };

--- a/src/components/PresetDetails/PresetDetails.tsx
+++ b/src/components/PresetDetails/PresetDetails.tsx
@@ -1,0 +1,49 @@
+import React, { useCallback } from 'react';
+import { TextField } from '@mui/material';
+import TextareaAutosize from '@mui/base/TextareaAutosize';
+import './PresetDetails.css';
+import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+
+import { selectPreset, setNotes } from '../../redux/store/reducers/preset-reducer';
+
+export const PresetDetails = (): JSX.Element => {
+  const dispatch = useAppDispatch();
+  const {
+    presetName,
+    notes
+  } = useAppSelector(selectPreset);
+
+  const onNotesChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      // TODO: Emojify it
+      dispatch(setNotes(event.currentTarget.value));
+    },
+    [notes]
+  );
+
+  return (
+    <>
+      <fieldset className="preset-details">
+        <legend>Details</legend>
+        <TextField
+          label="Name"
+          value={presetName}
+          disabled
+          fullWidth
+        />
+        <div>
+          <TextareaAutosize
+            placeholder="Notes"
+            className="preset-details__notes"
+            minRows={2}
+            maxRows={4}
+            value={notes}
+            onChange={onNotesChange}
+            spellCheck={false}
+          />
+        </div>
+      </fieldset>
+    {/* TODO Add notes */}
+    </>
+  );
+};

--- a/src/components/PresetSection/PresetSection.css
+++ b/src/components/PresetSection/PresetSection.css
@@ -1,7 +1,3 @@
-.preset-and-actions {
-  display: flex;
-}
-
 .preset-section {
   display: flex;
   flex-direction: column;
@@ -11,4 +7,8 @@
 
 .preset-section > div {
   margin: 10px;
+}
+
+.preset-section__sidebar {
+  margin-left: 16px;
 }

--- a/src/components/PresetSection/PresetSection.tsx
+++ b/src/components/PresetSection/PresetSection.tsx
@@ -13,6 +13,7 @@ import { Fade, Typography } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress/CircularProgress';
 import { PresetActions } from '../PresetActions/PresetActions';
 import './PresetSection.css';
+import { PresetDetails } from '../PresetDetails/PresetDetails';
 
 export const PresetSection = (): JSX.Element => {
   const dispatch = useAppDispatch();
@@ -56,13 +57,16 @@ export const PresetSection = (): JSX.Element => {
           <Fade in={!isPresetLoading}>
             <div className="preset-section">
               <PresetName />
-              <div className="preset-and-actions">
+              <div className="d-flex">
                 <PresetEditor
                   setExportRef={presetExportRefCallback}
                 />
-                <PresetActions
-                  presetExportRef={presetExportRef}
-                />
+                <div className="preset-section__sidebar">
+                  <PresetDetails />
+                  <PresetActions
+                    presetExportRef={presetExportRef}
+                  />
+                </div>
               </div>
               <PresetBreakdown />
             </div>

--- a/src/components/PresetSection/PresetSection.tsx
+++ b/src/components/PresetSection/PresetSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { useAppDispatch } from '../../redux/hooks';
@@ -20,17 +20,23 @@ export const PresetSection = (): JSX.Element => {
 
   const [presetExportRef, setPresetExportRef] = useState<HTMLDivElement | null>(null);
   const [isPresetLoading, setIsPresetLoading] = useState(false);
+  const presetImported = useRef(false);
 
   // Preset ID is stored in URL params
   const { id } = useParams();
 
   useEffect(() => {
+    if (presetImported.current) {
+      return;
+    }
+
     // load preset from URL if code exists
     const getPresetData = async (): Promise<void> => {
       if (id === undefined) {
         return;
       }
 
+      presetImported.current = true;
       setIsPresetLoading(true);
       const response = await getPreset(id);
       dispatch(importDataAction(response));

--- a/src/components/PresetSection/presetSectionApi.ts
+++ b/src/components/PresetSection/presetSectionApi.ts
@@ -15,12 +15,14 @@ export const GetPreset = async (id: string): Promise<SavedPresetData> => {
 const unpackData = async (stored: {
   equipmentSlots: any
   presetName: any
+  presetNotes: string
   inventorySlots: string | any[]
 }): Promise<SavedPresetData> => {
   const newPreset: SavedPresetData = {
     presetName: '',
     inventorySlots: [],
-    equipmentSlots: []
+    equipmentSlots: [],
+    presetNotes: ''
   };
   // create a map of all item labels to their default object
   const itemDataMap = new Map();

--- a/src/redux/store/reducers/preset-reducer.ts
+++ b/src/redux/store/reducers/preset-reducer.ts
@@ -19,6 +19,7 @@ interface PresetState {
   breakdown: Breakdown[]
   slotType: SlotType
   slotIndex: number
+  notes: string
 }
 
 interface IndexedSlot<T> {
@@ -62,6 +63,7 @@ const initialState: PresetState = {
     alternativeRelics: fillArrayWithSlotData(3)
   },
   breakdown: [],
+  notes: '',
   slotType: SlotType.Inventory,
   slotIndex: -1
 };
@@ -78,6 +80,7 @@ export const presetSlice = createSlice({
       state.relics = initialState.relics;
       state.familiars = initialState.familiars;
       state.breakdown = initialState.breakdown;
+      state.notes = initialState.notes;
     },
     setPresetName: (state: PresetState, action: PayloadAction<string>) => {
       state.presetName = action.payload;
@@ -111,6 +114,9 @@ export const presetSlice = createSlice({
     },
     setAlternativeFamiliar: (state: PresetState, action: PayloadAction<FamiliarSlot>) => {
       state.familiars.alternativeFamiliars[action.payload.index] = action.payload.value;
+    },
+    setNotes: (state: PresetState, action: PayloadAction<string>) => {
+      state.notes = action.payload;
     },
     setEntireBreakdown: (
       state: PresetState,
@@ -176,6 +182,7 @@ export const {
   setAlternativeFamiliar,
   setEntireBreakdown,
   setBreakdown,
+  setNotes,
   importDataAction,
   updateSlotType,
   updateSlotIndex,

--- a/src/redux/store/reducers/preset-reducer.ts
+++ b/src/redux/store/reducers/preset-reducer.ts
@@ -12,6 +12,7 @@ import { type RelicData, type Relics } from '../../../types/relic';
 // Define a type for the slice state
 interface PresetState {
   presetName: string
+  presetNotes: string
   inventorySlots: ItemData[]
   equipmentSlots: ItemData[]
   familiars: Familiars
@@ -19,7 +20,6 @@ interface PresetState {
   breakdown: Breakdown[]
   slotType: SlotType
   slotIndex: number
-  notes: string
 }
 
 interface IndexedSlot<T> {
@@ -46,6 +46,7 @@ const fillArrayWithSlotData = (numItems: number): any[] =>
 // Define the initial state using that type
 const initialState: PresetState = {
   presetName: '',
+  presetNotes: '',
   inventorySlots: Array.from({ length: 28 }, () => ({
     name: '',
     image: '',
@@ -63,7 +64,6 @@ const initialState: PresetState = {
     alternativeRelics: fillArrayWithSlotData(3)
   },
   breakdown: [],
-  notes: '',
   slotType: SlotType.Inventory,
   slotIndex: -1
 };
@@ -75,12 +75,12 @@ export const presetSlice = createSlice({
   reducers: {
     resetToInitialState: (state: PresetState) => {
       state.presetName = initialState.presetName;
+      state.presetNotes = initialState.presetNotes;
       state.inventorySlots = initialState.inventorySlots;
       state.equipmentSlots = initialState.equipmentSlots;
       state.relics = initialState.relics;
       state.familiars = initialState.familiars;
       state.breakdown = initialState.breakdown;
-      state.notes = initialState.notes;
     },
     setPresetName: (state: PresetState, action: PayloadAction<string>) => {
       state.presetName = action.payload;
@@ -115,8 +115,8 @@ export const presetSlice = createSlice({
     setAlternativeFamiliar: (state: PresetState, action: PayloadAction<FamiliarSlot>) => {
       state.familiars.alternativeFamiliars[action.payload.index] = action.payload.value;
     },
-    setNotes: (state: PresetState, action: PayloadAction<string>) => {
-      state.notes = action.payload;
+    setPresetNotes: (state: PresetState, action: PayloadAction<string>) => {
+      state.presetNotes = action.payload;
     },
     setEntireBreakdown: (
       state: PresetState,
@@ -173,6 +173,7 @@ export const presetSlice = createSlice({
 export const {
   resetToInitialState,
   setPresetName,
+  setPresetNotes,
   setInventorySlot,
   swapInventorySlots,
   setEquipmentSlot,
@@ -182,7 +183,6 @@ export const {
   setAlternativeFamiliar,
   setEntireBreakdown,
   setBreakdown,
-  setNotes,
   importDataAction,
   updateSlotType,
   updateSlotIndex,

--- a/src/store/local-storage.ts
+++ b/src/store/local-storage.ts
@@ -1,5 +1,5 @@
-import { SavedPresetData } from "../types/saved-preset-data";
-import { sanitizePresetData } from "../utility/sanitizer";
+import { type SavedPresetData } from '../types/saved-preset-data';
+import { sanitizePresetData } from '../utility/sanitizer';
 
 /**
  * Handles read/writes to localStorage. Currently used for:
@@ -9,9 +9,9 @@ import { sanitizePresetData } from "../utility/sanitizer";
 class LocalStorage {
   PRESETS_KEY = 'presets';
 
-  loadPresets() {
+  loadPresets (): SavedPresetData[] {
     const localStoragePresets = window.localStorage.getItem(this.PRESETS_KEY);
-    if (localStoragePresets) {
+    if (localStoragePresets !== undefined && localStoragePresets !== null) {
       const presetData: SavedPresetData[] = JSON.parse(localStoragePresets);
       return presetData;
     }
@@ -19,7 +19,7 @@ class LocalStorage {
     return [];
   }
 
-  savePresetWithoutConfirmation(presetData: SavedPresetData) {
+  savePresetWithoutConfirmation (presetData: SavedPresetData): void {
     const presetName = presetData.presetName;
     const sanitizedPresetData = sanitizePresetData(presetData);
     const currentPresets = this.loadPresets();
@@ -31,7 +31,7 @@ class LocalStorage {
     window.localStorage.setItem(this.PRESETS_KEY, JSON.stringify(updatedPresets));
   }
 
-  savePresetWithConfirmation(presetData: SavedPresetData) {
+  savePresetWithConfirmation (presetData: SavedPresetData): boolean {
     const presetName = presetData.presetName;
     const sanitizedPresetData = sanitizePresetData(presetData);
     const currentPresets = this.loadPresets();
@@ -53,11 +53,11 @@ class LocalStorage {
     return true;
   }
 
-  _replacePreset(currentPresets: SavedPresetData[], presetToReplace: SavedPresetData) {
+  _replacePreset (currentPresets: SavedPresetData[], presetToReplace: SavedPresetData): SavedPresetData[] {
     return currentPresets.map((preset) => {
       if (preset.presetName === presetToReplace.presetName) {
         return {
-          ...presetToReplace,
+          ...presetToReplace
         };
       }
 
@@ -65,7 +65,7 @@ class LocalStorage {
     });
   }
 
-  _isMatchingExistingPreset(currentPresets: SavedPresetData[], presetName: string) {
+  _isMatchingExistingPreset (currentPresets: SavedPresetData[], presetName: string): boolean {
     return currentPresets.findIndex((preset) =>
       preset.presetName.toLocaleUpperCase() === presetName.toLocaleUpperCase()) !== -1;
   }
@@ -75,4 +75,3 @@ const defaultInstance = new LocalStorage();
 export {
   defaultInstance as LocalStorage
 };
-

--- a/src/types/saved-preset-data.ts
+++ b/src/types/saved-preset-data.ts
@@ -21,4 +21,8 @@ export interface SavedPresetData {
    * Base64-encoded string.
    */
   presetImage?: string
+  /**
+   * Notes, with emoji and link support.
+   */
+  presetNotes?: string
 }

--- a/src/utility/sanitizer.ts
+++ b/src/utility/sanitizer.ts
@@ -41,6 +41,7 @@ export const sanitizeFamiliarData = (familiarDataArr: FamiliarData[] | undefined
 export const sanitizePresetData = (presetData: SavedPresetData): SavedPresetData => {
   return {
     presetName: presetData.presetName,
+    presetNotes: presetData.presetNotes,
     inventorySlots: sanitizeEntityData(presetData.inventorySlots),
     equipmentSlots: sanitizeEntityData(presetData.equipmentSlots),
     relics: {
@@ -58,6 +59,7 @@ export const sanitizePresetData = (presetData: SavedPresetData): SavedPresetData
 export const stringifyPreset = (sanitizedPresetData: SavedPresetData): string => {
   const {
     presetName,
+    presetNotes,
     inventorySlots,
     equipmentSlots,
     relics,
@@ -68,6 +70,7 @@ export const stringifyPreset = (sanitizedPresetData: SavedPresetData): string =>
   const { dateString, hours, minutes, seconds } = generateDateString();
   return JSON.stringify({
     presetName: presetName ?? `${dateString}-${hours}-${minutes}${seconds}`,
+    presetNotes,
     inventorySlots,
     equipmentSlots,
     relics,

--- a/src/utility/sanitizer.ts
+++ b/src/utility/sanitizer.ts
@@ -78,6 +78,7 @@ export const stringifyPreset = (sanitizedPresetData: SavedPresetData): string =>
 
 export const stringifyData = (
   presetName: string,
+  presetNotes: string,
   inventoryData: ItemData[],
   equipmentData: ItemData[],
   relicData: Relics,
@@ -90,6 +91,7 @@ export const stringifyData = (
     : `${dateString}-${hours}-${minutes}${seconds}`;
   return JSON.stringify({
     presetName: presetNameToUse,
+    presetNotes,
     inventorySlots: inventoryData,
     equipmentSlots: equipmentData,
     relics: relicData,


### PR DESCRIPTION
This adds a top-level preset notes field, in addition to;

* Consolidating formatted (emojis + links) notes into a single new component, `NotesField`
* Fixes a debouncing issue with formatting links where something like "youtube.co" would get formatted before they finished typing ".com"
* Fixes a bug where GetPreset was being called twice
* Fixes a bug where `presetName` wasn't being set when fetching a preset

UI:

![image](https://github.com/pvme/preset-maker/assets/3266047/ce6468d3-21c4-4751-8d50-6937b2943e86)
