### PR TITLE
refactor: move preset loading upwards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,7 @@
+html, body, #root {
+  height: 100%;
+}
+
 #root {
   width: 100vw;
   margin: 0 auto;
@@ -10,14 +14,20 @@
   margin-top: 64px;
 }
 
+.App--loading {
+  /* TODO */
+}
+
 .logo {
   height: 6em;
   padding: 1.5em;
   will-change: filter;
 }
+
 .logo:hover {
   filter: drop-shadow(0 0 2em #646cffaa);
 }
+
 .logo.react:hover {
   filter: drop-shadow(0 0 2em #61dafbaa);
 }
@@ -62,6 +72,10 @@
   width: 100%;
 }
 
+.height-100 {
+  height: 100%;
+}
+
 .d-flex {
   display: flex;
 }
@@ -81,6 +95,10 @@
 
 .m-8 {
   margin: 8px;
+}
+
+.m-16 {
+  margin: 16px;
 }
 
 .mh-8 {
@@ -138,17 +156,5 @@
 
   .width-50 {
     width: 100%;
-  }
-}
-
-@media (max-width: 400px) {
-  .App {
-    /* margin-top: 140px; */
-  }
-}
-
-@media (max-width: 308px) {
-  .App {
-    /* margin-top: 180px; */
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,62 @@
-import React from 'react';
-import { HeaderBar } from './components/HeaderBar/HeaderBar';
-import { PresetSection } from './components/PresetSection/PresetSection';
+import React, { useEffect, useRef, useState } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
+import { HeaderBar } from './components/HeaderBar/HeaderBar';
+import { PresetSection } from './components/PresetSection/PresetSection';
 
 import './App.css';
 import './Dialog.css';
+import { useParams } from 'react-router';
+import { useAppDispatch } from './redux/hooks';
+import { getPreset } from './api/get-preset';
+import { importDataAction } from './redux/store/reducers/preset-reducer';
+import { CircularProgress, Typography } from '@mui/material';
 
 function App (): JSX.Element {
+  const dispatch = useAppDispatch();
+  const [isPresetLoading, setIsPresetLoading] = useState(false);
+  const presetImported = useRef(false);
+
+  // Preset ID is stored in URL params
+  const { id } = useParams();
+
+  useEffect(() => {
+    if (presetImported.current) {
+      return;
+    }
+
+    // load preset from URL if code exists
+    const getPresetData = async (): Promise<void> => {
+      if (id === undefined) {
+        return;
+      }
+
+      presetImported.current = true;
+      setIsPresetLoading(true);
+      const response = await getPreset(id);
+      dispatch(importDataAction(response));
+      setIsPresetLoading(false);
+    };
+
+    void getPresetData();
+  }, [id]);
+
   return (
     <DndProvider backend={HTML5Backend}>
-      <div className="App">
-        <HeaderBar />
-        <PresetSection />
-      </div>
+      {isPresetLoading
+        ? <div className="height-100 d-flex flex-center">
+          <CircularProgress />
+          <Typography className="m-16" variant="h6">
+            Loading preset...
+          </Typography>
+        </div>
+        : (
+        <div className="App">
+          <HeaderBar />
+          <PresetSection />
+        </div>
+          )
+      }
     </DndProvider>
   );
 }

--- a/src/components/PresetSection/PresetSection.css
+++ b/src/components/PresetSection/PresetSection.css
@@ -12,3 +12,11 @@
 .preset-section__sidebar {
   margin-left: 16px;
 }
+
+/* Mobile styling */
+
+@media (max-width: 900px) {
+  .preset-section__inner {
+    flex-direction: column;
+  }
+}

--- a/src/components/PresetSection/PresetSection.tsx
+++ b/src/components/PresetSection/PresetSection.tsx
@@ -1,84 +1,38 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useState } from 'react';
 
-import { useAppDispatch } from '../../redux/hooks';
-import { importDataAction } from '../../redux/store/reducers/preset-reducer';
 import { PresetBreakdown } from '../PresetBreakdown/PresetBreakdown';
 import { PresetEditor } from '../PresetEditor/PresetEditor';
 import { PresetName } from '../PresetLoader/PresetLoader';
 
-import { getPreset } from '../../api/get-preset';
-
-import { Fade, Typography } from '@mui/material';
-import CircularProgress from '@mui/material/CircularProgress/CircularProgress';
+import { Fade } from '@mui/material';
 import { PresetActions } from '../PresetActions/PresetActions';
-import './PresetSection.css';
 import { PresetDetails } from '../PresetDetails/PresetDetails';
+import './PresetSection.css';
 
 export const PresetSection = (): JSX.Element => {
-  const dispatch = useAppDispatch();
-
   const [presetExportRef, setPresetExportRef] = useState<HTMLDivElement | null>(null);
-  const [isPresetLoading, setIsPresetLoading] = useState(false);
-  const presetImported = useRef(false);
-
-  // Preset ID is stored in URL params
-  const { id } = useParams();
-
-  useEffect(() => {
-    if (presetImported.current) {
-      return;
-    }
-
-    // load preset from URL if code exists
-    const getPresetData = async (): Promise<void> => {
-      if (id === undefined) {
-        return;
-      }
-
-      presetImported.current = true;
-      setIsPresetLoading(true);
-      const response = await getPreset(id);
-      dispatch(importDataAction(response));
-      setIsPresetLoading(false);
-    };
-
-    void getPresetData();
-  }, [id]);
 
   const presetExportRefCallback = (ref: HTMLDivElement): void => {
     setPresetExportRef(ref);
   };
 
   return (
-    <>
-      {isPresetLoading
-        ? <div className="preset-section--loading">
-          <CircularProgress />
-          <Typography className="mt-8" variant="h6">
-            Loading preset...
-          </Typography>
+    <Fade in={true}>
+      <div className="preset-section">
+        <PresetName />
+        <div className="preset-section__inner d-flex">
+          <PresetEditor
+            setExportRef={presetExportRefCallback}
+          />
+          <div className="preset-section__sidebar">
+            <PresetDetails />
+            <PresetActions
+              presetExportRef={presetExportRef}
+            />
+          </div>
         </div>
-        : (
-          <Fade in={!isPresetLoading}>
-            <div className="preset-section">
-              <PresetName />
-              <div className="d-flex">
-                <PresetEditor
-                  setExportRef={presetExportRefCallback}
-                />
-                <div className="preset-section__sidebar">
-                  <PresetDetails />
-                  <PresetActions
-                    presetExportRef={presetExportRef}
-                  />
-                </div>
-              </div>
-              <PresetBreakdown />
-            </div>
-          </Fade>
-          )
-      }
-    </>
+        <PresetBreakdown />
+      </div>
+    </Fade>
   );
 };


### PR DESCRIPTION
This improves the UX for loading by displaying a full width/height screen with the loading spinner. This was done by moving the logic for fetching the preset upwards into `App`.