### PR TITLE
fix: Dynamically stretch background color to fit entire page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 html, body, #root {
-  height: 100%;
+  min-height: 100vh;
 }
 
 #root {


### PR DESCRIPTION
Extending the black background to entire screen, even if there's a scrollbar and content extending the view.

Before:
![image](https://github.com/pvme/preset-maker/assets/9580545/1b6bff8d-cc90-4178-875e-a76ba93c28cd)

After:
![image](https://github.com/pvme/preset-maker/assets/9580545/bdb17b13-cee6-4e7e-be20-86bfa3e8eed5)