### PR TITLE
fix: remove max-height on relic-familiar container

### DIFF
--- a/src/components/PresetEditor/PresetEditor.css
+++ b/src/components/PresetEditor/PresetEditor.css
@@ -3,7 +3,6 @@
   justify-content: space-evenly;
   text-align: center;
   height: 100%;
-  max-height: 218px;
   background-image: url("https://i.imgur.com/HSATCDr.png");
   padding: 4px;
   border: 1px solid rgb(100, 100, 100, 0.5);
@@ -28,7 +27,6 @@
 
   .relics-familiar-container {
     max-width: 100vw;
-    max-height: 420px;
     flex-direction: column;
   }
 }


### PR DESCRIPTION
Before:

![image](https://github.com/pvme/preset-maker/assets/3266047/8745256a-adf2-45ef-8479-9981b983656f)

After:

![image](https://github.com/pvme/preset-maker/assets/3266047/37919a3a-7828-4437-bc2b-c4a9c0d84019)
