### PR TITLE
enh: add domain check to item sorting script

### DIFF
--- a/src/data/scripts/item_sorter.py
+++ b/src/data/scripts/item_sorter.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 def find_duplicate_objects(json_array):
     labels = set()
@@ -11,16 +12,31 @@ def find_duplicate_objects(json_array):
             labels.add(label)
     return duplicates
 
+def find_invalid_domains(json_array):
+    invalid_domains = []
+    for obj in json_array:
+        image = obj.get("image")
+        if "https://i.imgur.com" not in image:
+          invalid_domains.append(obj.get("label") + " - " + image)
+    return invalid_domains
 
-with open('src\data\sorted_items.json') as f:
+# Works for both Unix/macOS and Windows
+sorted_items_path = os.path.join('src', 'data', 'sorted_items.json')
+
+with open(sorted_items_path) as f:
     data = json.load(f)
     duplicates = find_duplicate_objects(data)
     if duplicates:
         print("The following objects have duplicate labels:")
         for obj in duplicates:
             print(obj)
+    invalid_domains = find_invalid_domains(data)
+    if invalid_domains:
+        print("The following objects have invalid domains ('i.imgur.com' must be used, not 'imgur.com):")
+        for obj in invalid_domains:
+            print(obj)
 
 sorted_data = sorted(data, key=lambda x: x['name'])
 
-with open('src\data\sorted_items.json', 'w') as f:
+with open(sorted_items_path, 'w') as f:
     json.dump(sorted_data, f, indent='\t', separators=(',', ': '))

--- a/src/data/scripts/item_sorter.py
+++ b/src/data/scripts/item_sorter.py
@@ -12,11 +12,13 @@ def find_duplicate_objects(json_array):
             labels.add(label)
     return duplicates
 
+# Additional valid domains can be added here
+valid_domains = ["https://i.imgur.com"]
 def find_invalid_domains(json_array):
     invalid_domains = []
     for obj in json_array:
         image = obj.get("image")
-        if "https://i.imgur.com" not in image:
+        if not any(image.startswith(domain) for domain in valid_domains):
           invalid_domains.append(obj.get("label") + " - " + image)
     return invalid_domains
 
@@ -32,7 +34,7 @@ with open(sorted_items_path) as f:
             print(obj)
     invalid_domains = find_invalid_domains(data)
     if invalid_domains:
-        print("The following objects have invalid domains ('i.imgur.com' must be used, not 'imgur.com):")
+        print("The following objects have invalid domains (valid domains = " + ', '.join(valid_domains, ) + "):")
         for obj in invalid_domains:
             print(obj)
 

--- a/src/data/sorted_items.json
+++ b/src/data/sorted_items.json
@@ -849,7 +849,7 @@
 	},
   {
 		"label": "barrelchestanchor",
-		"image": "https://imgur.com/wE3rGjg.png",
+		"image": "https://i.imgur.com/wE3rGjg.png",
 		"name": "Barrelchest Anchor",
 		"breakdownNotes": "",
 		"slot": 4,
@@ -5873,7 +5873,7 @@
 	},
   {
 		"label": "occulistsring",
-		"image": "https://imgur.com/bCYjo7u.png",
+		"image": "https://i.imgur.com/bCYjo7u.png",
 		"name": "Occulist's Ring",
 		"breakdownNotes": "",
 		"slot": 11,


### PR DESCRIPTION
Example output:

```
The following objects have invalid domains (valid domains = https://i.imgur.com):
barrelchestanchor - https://imgur.com/wE3rGjg.png
occulistsring - https://imgur.com/bCYjo7u.png
```

Cross-platform file path support is also added so the script can be run on both Windows and Unix/macOS without issues.