### PR TITLE
fix: clear relics from arrays

### DIFF
--- a/src/components/RelicSection/RelicSection.tsx
+++ b/src/components/RelicSection/RelicSection.tsx
@@ -89,10 +89,10 @@ export const RelicSection = (): JSX.Element => {
     setDialogOpen(false);
   }, []);
 
-  const handleRelicSelection = useCallback((indexedSelection: IndexedSelection, relic: RelicData) => {
+  const handleRelicSelection = useCallback((indexedSelection: IndexedSelection, relic: RelicData | null) => {
     if (indexedSelection.primaryOrAlternative === PrimaryOrAlternative.Primary) {
       // Prevent duplicates.
-      if (relics.primaryRelics.includes(relic)) {
+      if ((relic != null) && relics.primaryRelics.includes(relic)) {
         return;
       }
 
@@ -102,7 +102,7 @@ export const RelicSection = (): JSX.Element => {
       }));
     } else if (indexedSelection.primaryOrAlternative === PrimaryOrAlternative.Alternative) {
       // Prevent duplicates.
-      if (relics.alternativeRelics.includes(relic)) {
+      if ((relic != null) && relics.alternativeRelics.includes(relic)) {
         return;
       }
 

--- a/src/components/dialogs/RelicSelectDialogPopup/RelicSelectDialog.tsx
+++ b/src/components/dialogs/RelicSelectDialogPopup/RelicSelectDialog.tsx
@@ -27,7 +27,7 @@ interface RelicSelectDialogProps {
   open: boolean
   indexedSelection: IndexedSelection
   handleClose: () => void
-  handleSelection: (indexedSelection: IndexedSelection, relic: RelicData) => void
+  handleSelection: (indexedSelection: IndexedSelection, relic: RelicData | null) => void
 }
 
 const dialogBaseHeight = 130;
@@ -102,13 +102,7 @@ export const RelicSelectDialog = ({
   );
 
   const clearCell = useCallback(() => {
-    handleSelection(indexedSelection, {
-      name: '',
-      image: '',
-      label: '',
-      breakdownNotes: '',
-      energy: undefined
-    });
+    handleSelection(indexedSelection, null);
     handleClose();
   }, [indexedSelection]);
 

--- a/src/redux/store/reducers/preset-reducer.ts
+++ b/src/redux/store/reducers/preset-reducer.ts
@@ -33,7 +33,7 @@ interface SwapSlots {
   targetIndex: number
 }
 type FamiliarSlot = IndexedSlot<FamiliarData>;
-type RelicSlot = IndexedSlot<RelicData>;
+type RelicSlot = IndexedSlot<RelicData | null>;
 
 const fillArrayWithSlotData = (numItems: number): any[] =>
   new Array(numItems).fill({
@@ -104,10 +104,18 @@ export const presetSlice = createSlice({
       state.equipmentSlots[action.payload.index] = action.payload.value;
     },
     setPrimaryRelic: (state: PresetState, action: PayloadAction<RelicSlot>) => {
-      state.relics.primaryRelics[action.payload.index] = action.payload.value;
+      if (action.payload.value != null) {
+        state.relics.primaryRelics[action.payload.index] = action.payload.value;
+      } else {
+        state.relics.primaryRelics.splice(action.payload.index, 1);
+      }
     },
     setAlternativeRelic: (state: PresetState, action: PayloadAction<RelicSlot>) => {
-      state.relics.alternativeRelics[action.payload.index] = action.payload.value;
+      if (action.payload.value != null) {
+        state.relics.alternativeRelics[action.payload.index] = action.payload.value;
+      } else {
+        state.relics.alternativeRelics.splice(action.payload.index, 1);
+      }
     },
     setPrimaryFamiliar: (state: PresetState, action: PayloadAction<FamiliarSlot>) => {
       state.familiars.primaryFamiliars[action.payload.index] = action.payload.value;


### PR DESCRIPTION
We were previously updating relics to an object populated with empty strings when cleare, based on the index. This means that if you added 3 relics and cleared the first two, the alternativeRelics array would still be of length 3. Within the UI components, though, the array would be of length 1 so the indices wouldn't match.

This change clears relics from the array entirely so that indices always match.