### PR TITLE
Update sorted_items.json

### DIFF
--- a/src/data/sorted_items.json
+++ b/src/data/sorted_items.json
@@ -828,7 +828,7 @@
 		"image": "https://img.pvme.io/images/KxkWRxPBoB.png",
 		"name": "Balarak's sash brush",
 		"breakdownNotes": "",
-		"slot": 4,
+		"slot": 5,
 		"wikiLink": "https://runescape.wiki/w/Balarak%27s_sash_brush"
 	},
 	{


### PR DESCRIPTION
Moved Balarak's sash brush to the correct equipment slot (it was previously classified as MH instead of OH).