### PR TITLE
Add Amascut items, tele tabs, and fami

### DIFF
--- a/src/data/sorted_familiars.json
+++ b/src/data/sorted_familiars.json
@@ -78,6 +78,12 @@
 		"breakdownNotes": ""
 	},
 	{
+		"label": "lesserdemondeacon",
+		"image": "https://img.pvme.io/images/exNEDsDd7B.png",
+		"name": "Lesser demon deacon",
+		"breakdownNotes": ""
+	},
+	{
 		"label": "meerkats",
 		"image": "https://img.pvme.io/images/cOwxYnD.png",
 		"name": "Meerkats",

--- a/src/data/sorted_items.json
+++ b/src/data/sorted_items.json
@@ -1880,6 +1880,14 @@
 		"wikiLink": "https://runescape.wiki/w/Cywir_wand"
 	},
 	{
+		"label": "dksteleport",
+		"image": "https://img.pvme.io/images/WybIH5cKeP.png",
+		"name": "Dagannoth Kings teleport",
+		"breakdownNotes": "",
+		"slot": 0,
+		"wikiLink": "https://runescape.wiki/w/Dagannoth_Kings_teleport"
+	},
+	{
 		"label": "damagedarmournoted",
 		"image": "https://img.pvme.io/images/qzQyPALQRN.png",
 		"name": "Damaged armour (noted)",
@@ -1966,6 +1974,14 @@
 		"breakdownNotes": "",
 		"slot": 13,
 		"wikiLink": "https://runescape.wiki/w/Dave's_spellbook"
+	},
+	{
+		"label": "deacondemonpouch",
+		"image": "https://img.pvme.io/images/5MZPj7F7ip.png",
+		"name": "Deacon demon pouch",
+		"breakdownNotes": "",
+		"slot": 0,
+		"wikiLink": "https://runescape.wiki/w/Deacon_demon_pouch"
 	},
 	{
 		"label": "deathguardt70",
@@ -2838,6 +2854,14 @@
 		"breakdownNotes": "",
 		"slot": 0,
 		"wikiLink": "https://runescape.wiki/w/Earth_rune"
+	},
+	{
+		"label": "easternanachroniateleport",
+		"image": "https://img.pvme.io/images/93sRx4RSK3.png",
+		"name": "Eastern anachronia teleport",
+		"breakdownNotes": "",
+		"slot": 0,
+		"wikiLink": "https://runescape.wiki/w/Eastern_anachronia_teleport_(item)"
 	},
 	{
 		"label": "easyclue",
@@ -5256,6 +5280,14 @@
 		"wikiLink": "https://runescape.wiki/w/Legendary_tracker_aura"
 	},
 	{
+		"label": "lesserdemonscrolls500",
+		"image": "https://img.pvme.io/images/2SKjqYspC4.png",
+		"name": "Lesser Demon scroll (Ring of Fire)",
+		"breakdownNotes": "",
+		"slot": 0,
+		"wikiLink": "https://runescape.wiki/w/Lesser_Demon_scroll_(Ring_of_Fire)"
+	},
+	{
 		"label": "leviathanring",
 		"image": "https://img.pvme.io/images/OwpbyOe.png",
 		"name": "Leviathan ring",
@@ -6238,6 +6270,22 @@
 		"breakdownNotes": "",
 		"slot": 3,
 		"wikiLink": "https://runescape.wiki/w/Nimble_legwear"
+	},
+	{
+		"label": "nwanachroniateleport",
+		"image": "https://img.pvme.io/images/XLJvjJIgx1.png",
+		"name": "North-western anachronia teleport",
+		"breakdownNotes": "",
+		"slot": 0,
+		"wikiLink": "https://runescape.wiki/w/North-western_anachronia_teleport_(item)"
+	},
+	{
+		"label": "northernlostgroveteleport",
+		"image": "https://img.pvme.io/images/A6NgrUVPcC.png",
+		"name": "Northern lost grove teleport",
+		"breakdownNotes": "",
+		"slot": 0,
+		"wikiLink": "https://runescape.wiki/w/Northern_lost_grove_teleport_(item)"
 	},
 	{
 		"label": "noteditems",

--- a/src/data/sorted_items.json
+++ b/src/data/sorted_items.json
@@ -8833,7 +8833,7 @@
 	},
  	{
 		"label": "devourersnexus",
-		"image": "https://img.pvme.io/images/eirYlnU.png",
+		"image": "https://img.pvme.io/images/b4A3pZdcWR.png",
 		"name": "The Devourer's Nexus",
 		"breakdownNotes": "",
 		"slot": 9,

--- a/src/data/sorted_items.json
+++ b/src/data/sorted_items.json
@@ -1303,6 +1303,14 @@
 		"slot": 7,
 		"wikiLink": "https://runescape.wiki/w/Boots_of_Trials"
 	},
+ 	{
+		"label": "tumekenboots",
+		"image": "https://img.pvme.io/images/OBTrhWAa2M.png",
+		"name": "Boots of Tumeken's resplendence",
+		"breakdownNotes": "",
+		"slot": 7,
+		"wikiLink": "https://runescape.wiki/w/Boots_of_Tumeken%27s_resplendence"
+	}, 
 	{
 		"label": "subjboots",
 		"image": "https://img.pvme.io/images/7XWA1eE.png",
@@ -2383,6 +2391,14 @@
 		"slot": 10,
 		"wikiLink": "https://runescape.wiki/w/Desert_amulet_4"
 	},
+ 	{
+		"label": "devourersguard",
+		"image": "https://img.pvme.io/images/4JhPfydPPJ.png",
+		"name": "Devourer's Guard",
+		"breakdownNotes": "",
+		"slot": 4,
+		"wikiLink": "https://runescape.wiki/w/Devourer%27s_Guard"
+	}, 
 	{
 		"label": "diamond",
 		"image": "https://img.pvme.io/images/s637l2j.png",
@@ -3943,6 +3959,14 @@
 		"slot": 6,
 		"wikiLink": "https://runescape.wiki/w/Gloves_of_subjugation"
 	},
+ 	{
+		"label": "tumekengloves",
+		"image": "https://img.pvme.io/images/T28B23e7Kl.png",
+		"name": "Gloves of Tumeken's resplendence",
+		"breakdownNotes": "",
+		"slot": 6,
+		"wikiLink": "https://runescape.wiki/w/Gloves_of_Tumeken%27s_resplendence"
+	}, 
 	{
 		"label": "goblinvillagesphere",
 		"image": "https://img.pvme.io/images/4FOxSHk.png",
@@ -5590,6 +5614,14 @@
 		"breakdownNotes": "",
 		"slot": 1,
 		"wikiLink": "https://runescape.wiki/w/Mask_of_the_Kura"
+	},
+  {
+		"label": "tumekenmask",
+		"image": "https://img.pvme.io/images/pPm6gvnblB.png",
+		"name": "Mask of Tumeken's resplendence",
+		"breakdownNotes": "",
+		"slot": 1,
+		"wikiLink": "https://runescape.wiki/w/Mask_of_Tumeken%27s_resplendence"
 	},
 	{
 		"label": "masterarchaeologistsjacket",
@@ -7367,6 +7399,14 @@
 		"slot": 3,
 		"wikiLink": "https://runescape.wiki/w/Robe_bottom_of_the_First_Necromancer"
 	},
+ 	{
+		"label": "tumekenrobebottom",
+		"image": "https://img.pvme.io/images/ozNOXe1k1t.png",
+		"name": "Robe bottom of Tumeken's resplendence",
+		"breakdownNotes": "",
+		"slot": 3,
+		"wikiLink": "https://runescape.wiki/w/Robe_bottom_of_Tumeken%27s_resplendence"
+	}, 
 	{
 		"label": "t95necrotop",
 		"image": "https://img.pvme.io/images/VwEHIYQ.png",
@@ -7375,6 +7415,14 @@
 		"slot": 2,
 		"wikiLink": "https://runescape.wiki/w/Robe_top_of_the_First_Necromancer"
 	},
+ 	{
+		"label": "tumekenrobetop",
+		"image": "https://img.pvme.io/images/pNqN5aiYwr.png",
+		"name": "Robe top of Tumeken's resplendence",
+		"breakdownNotes": "",
+		"slot": 2,
+		"wikiLink": "https://runescape.wiki/w/Robe_top_of_Tumeken%27s_resplendence"
+	}, 
 	{
 		"label": "rockcrushingscrimshaw",
 		"image": "https://img.pvme.io/images/caaJeHr.png",
@@ -8783,6 +8831,14 @@
 		"slot": 0,
 		"wikiLink": "https://runescape.wiki/w/Tetracompass_(powered)"
 	},
+ 	{
+		"label": "devourersnexus",
+		"image": "https://img.pvme.io/images/eirYlnU.png",
+		"name": "The Devourer's Nexus",
+		"breakdownNotes": "",
+		"slot": 9,
+		"wikiLink": "https://runescape.wiki/w/The_Devourer%27s_Nexus"
+	}, 
 	{
 		"label": "theheartteleport",
 		"image": "https://img.pvme.io/images/eirYlnU.png",
@@ -9023,6 +9079,14 @@
 		"slot": 3,
 		"wikiLink": "https://runescape.wiki/w/Trimmed_masterwork_platelegs"
 	},
+ 	{
+		"label": "tumekenslight",
+		"image": "https://img.pvme.io/images/lVVjHYAmiS.png",
+		"name": "Tumeken's Light",
+		"breakdownNotes": "",
+		"slot": 4,
+		"wikiLink": "https://runescape.wiki/w/Tumeken%27s_Light"
+	}, 
 	{
 		"label": "ugthankidung",
 		"image": "https://img.pvme.io/images/PrcTHTb.png",


### PR DESCRIPTION
### Add 
- Devourer's Guard
- The Devourer's Nexus
- Tumeken's Light
- Tumeken's resplendence equipment
- North-western anachronia teleport
- Eastern anachronia teleport
- Northern lost grove teleport
- Dagannoth Kings teleport
- Deacon demon pouch
- Lesser Demon scroll (Ring of Fire)
- Lesser demon deacon (sorted_familiars.json)